### PR TITLE
Implement wrapper in `fusion-test-utils` to encapsulate plugin resolution

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,14 +1,15 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
+<PROJECT_ROOT>/dist/.*
 
 [include]
 ./src/
 
 [libs]
+./node_modules/fusion-core/flow-typed
 
 [lints]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
 
 [strict]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ yarn add fusion-test-utils
 
 ```js
 import App from 'fusion-core';
-import {render, request} from 'fusion-test-utils';
+import {getSimulator} from 'fusion-test-utils';
+
+// create simulator
+const app = new App();
+const simulator = getSimulator(app /*, (optional) test plugin with assertions on dependencies */);
 
 // test renders of your application
-const app = new App();
-const ctx = await render(app, '/test-url', {
+const ctx = await simulator.render(app, '/test-url', {
   headers: {
     'x-header': 'value',
   }
@@ -26,8 +29,7 @@ const ctx = await render(app, '/test-url', {
 // do assertions on ctx
 
 // test requests to your application
-const app = new App();
-const ctx = await request(app, '/test-url', {
+const ctx = await simulator.request(app, '/test-url', {
   headers: {
     'x-header': 'value',
   }
@@ -39,17 +41,22 @@ const ctx = await request(app, '/test-url', {
 
 ### API
 
-#### `request(app: FusionApp, url: String, options: ?Object)` => Promise<ctx>
+#### `getSimulator(app: FusionApp, testPlugin?: FusionPlugin) => { request, render }`
+
+Creates a simulator which exposes functionality to simulate requests and renders through your application.
+`app` - instance of a FusionApp
+`testPlugin` - optional plugin to make assertions on dependencies
+
+#### `getSimulator(...).request(url: String, options: ?Object)` => Promise<ctx>
 
 Simulates a request through your application.
-`app` - instance of a FusionApp
 `url` - path for request
 `options` - optional object containing custom settings for the request
 `options.method` - the request method, e.g., GET, POST,
 `options.headers` - headers to be added to the request
 `options.body` - body for the request
 
-#### `render(app: FusionApp, url: String, options: ?Object)` => Promise<ctx>
+#### `getSimulator(...).render(url: String, options: ?Object)` => Promise<ctx>
 
 This is the same as `request`, but defaults the `accept` header to `text/html` which will trigger a render of your application.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "7.5.1",
     "flow-bin": "0.63.1",
     "fusion-core": "0.3.0-2",
+    "fusion-tokens": "^0.0.4",
     "jest": "22.0.6",
     "jest-cli": "22.0.6",
     "nyc": "11.4.1",
@@ -61,7 +62,8 @@
     "node-mocks-http": "^1.6.6"
   },
   "peerDependencies": {
-    "fusion-core": ">=0.3.0-2"
+    "fusion-core": ">=0.3.0-2",
+    "fusion-tokens": "^0.0.4"
   },
   "engines": {
     "node": ">= 8.9.0"

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -2,7 +2,7 @@ import test from 'tape-cup';
 import App, {withDependencies} from 'fusion-core';
 import {createToken} from 'fusion-tokens';
 
-import {registerAsTest, test as exportedTest} from '../index.js';
+import {getSimulator, test as exportedTest} from '../index.js';
 
 test('simulate render request', async t => {
   const flags = {render: false};
@@ -11,7 +11,7 @@ test('simulate render request', async t => {
     flags.render = true;
   };
   const app = new App(element, renderFn);
-  var testApp = registerAsTest(app);
+  var testApp = getSimulator(app);
   const ctx = await testApp.render('/');
   t.ok(flags.render, 'triggered ssr');
   t.ok(ctx.element, 'sets ctx.element');
@@ -24,7 +24,7 @@ test('simulate multi-render requests', async t => {
     counter.renderCount++;
   };
   const app = new App('hello', renderFn);
-  var testApp = registerAsTest(app);
+  var testApp = getSimulator(app);
 
   for (var i = 1; i <= 5; i++) {
     await testApp.render('/');
@@ -41,7 +41,7 @@ test('simulate non-render request', async t => {
     flags.render = true;
   };
   const app = new App(element, renderFn);
-  const testApp = registerAsTest(app);
+  const testApp = getSimulator(app);
   if (__BROWSER__) {
     try {
       testApp.request('/');
@@ -72,7 +72,7 @@ test('use simulator with fixture and plugin dependencies', async t => {
   const app = getTestFixture();
 
   t.plan(3);
-  registerAsTest(
+  getSimulator(
     app,
     withDependencies({
       msgProvider: msgProviderPluginToken,

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -59,14 +59,17 @@ test('simulate non-render request', async t => {
   }
 });
 
-test('simulate with plugin dependencies', async t => {
+test('use simulator with fixture and plugin dependencies', async t => {
   // Dependency-less plugin
   const msgProviderPluginToken = createToken('MessageProviderPluginToken');
   const msgProviderPlugin = {msg: 'it works!'};
-
-  // Register plugins
-  const app = new App('hi', el => el);
-  app.register(msgProviderPluginToken, () => msgProviderPlugin);
+  function getTestFixture() {
+    // Register plugins
+    const app = new App('hi', el => el);
+    app.register(msgProviderPluginToken, () => msgProviderPlugin);
+    return app;
+  }
+  const app = getTestFixture();
 
   t.plan(3);
   registerAsTest(

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,7 @@
 import test from 'tape-cup';
 import App from 'fusion-core';
 
-import {render, request, test as exportedTest} from '../index.js';
+import {registerAsTest, test as exportedTest} from '../index.js';
 
 test('simulate render request', async t => {
   const flags = {render: false};
@@ -10,9 +10,26 @@ test('simulate render request', async t => {
     flags.render = true;
   };
   const app = new App(element, renderFn);
-  const ctx = await render(app, '/');
+  var testApp = registerAsTest(app);
+  const ctx = await testApp.render('/');
   t.ok(flags.render, 'triggered ssr');
   t.ok(ctx.element, 'sets ctx.element');
+  t.end();
+});
+
+test('simulate multi-render requests', async t => {
+  const counter = {renderCount: 0};
+  const renderFn = () => {
+    counter.renderCount++;
+  };
+  const app = new App('hello', renderFn);
+  var testApp = registerAsTest(app);
+
+  for (var i = 1; i <= 5; i++) {
+    await testApp.render('/');
+    t.equal(counter.renderCount, i, `#${i} ssr render successful`);
+  }
+
   t.end();
 });
 
@@ -23,9 +40,10 @@ test('simulate non-render request', async t => {
     flags.render = true;
   };
   const app = new App(element, renderFn);
+  const testApp = registerAsTest(app);
   if (__BROWSER__) {
     try {
-      await request(app, '/');
+      testApp.request('/');
       t.fail('should have thrown');
     } catch (e) {
       t.ok(e, 'throws an error');
@@ -33,7 +51,7 @@ test('simulate non-render request', async t => {
       t.end();
     }
   } else {
-    const ctx = await request(app, '/');
+    const ctx = testApp.request('/');
     t.notok(ctx.element, 'does not set ctx.element');
     t.ok(!flags.render, 'did not trigger ssr');
     t.end();

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,18 @@
+//@flow
+
+import FusionApp from 'fusion-core';
+
 import assert from 'assert';
 import {mockContext, renderContext} from './mock-context.js';
 import simulate from './simulate';
 
-export function request(app, url, options = {}) {
+declare var __BROWSER__: boolean;
+
+export function request(
+  app: FusionApp,
+  url: string,
+  options: * = {}
+): Promise<*> {
   if (__BROWSER__) {
     throw new Error(
       '[fusion-test-utils] Request api not support from the browser. Please use `render` instead'
@@ -12,7 +22,11 @@ export function request(app, url, options = {}) {
   return simulate(app, ctx);
 }
 
-export function render(app, url, options = {}) {
+export function render(
+  app: FusionApp,
+  url: string,
+  options: * = {}
+): Promise<*> {
   const ctx = renderContext(url, options);
   return simulate(app, ctx);
 }
@@ -20,13 +34,17 @@ export function render(app, url, options = {}) {
 // Export test runner functions from jest
 // eslint-disable-next-line import/no-mutable-exports
 let mockFunction, test;
+// $FlowFixMe
 if (typeof it !== 'undefined') {
   // Surface snapshot testing
+  // $FlowFixMe
   assert.matchSnapshot = tree => expect(tree).toMatchSnapshot();
 
   /* eslint-env node, jest */
+  // $FlowFixMe
   test = (description, callback, ...rest) =>
     it(description, () => callback(assert), ...rest);
+  // $FlowFixMe
   mockFunction = (...args) => jest.fn(...args);
 } else {
   const notSupported = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,13 @@ const render = (app: FusionApp) => (
   return simulate(app, ctx);
 };
 
-export function registerAsTest(app: FusionApp, testPlugin: FusionPlugin<*, *>) {
-  app.register(testPlugin);
+export function registerAsTest(
+  app: FusionApp,
+  testPlugin?: FusionPlugin<*, *>
+) {
+  if (testPlugin) {
+    app.register(testPlugin);
+  }
   app.resolve();
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -31,10 +31,7 @@ const render = (app: FusionApp) => (
   return simulate(app, ctx);
 };
 
-export function registerAsTest(
-  app: FusionApp,
-  testPlugin?: FusionPlugin<*, *>
-) {
+export function getSimulator(app: FusionApp, testPlugin?: FusionPlugin<*, *>) {
   if (testPlugin) {
     app.register(testPlugin);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,19 @@
 //@flow
 
-import FusionApp from 'fusion-core';
-
 import assert from 'assert';
+
+import FusionApp from 'fusion-core';
+import type {FusionPlugin} from 'fusion-core';
+
 import {mockContext, renderContext} from './mock-context.js';
 import simulate from './simulate';
 
 declare var __BROWSER__: boolean;
 
-export function request(
-  app: FusionApp,
+const request = (app: FusionApp) => (
   url: string,
   options: * = {}
-): Promise<*> {
+): Promise<*> => {
   if (__BROWSER__) {
     throw new Error(
       '[fusion-test-utils] Request api not support from the browser. Please use `render` instead'
@@ -20,15 +21,24 @@ export function request(
   }
   const ctx = mockContext(url, options);
   return simulate(app, ctx);
-}
+};
 
-export function render(
-  app: FusionApp,
+const render = (app: FusionApp) => (
   url: string,
   options: * = {}
-): Promise<*> {
+): Promise<*> => {
   const ctx = renderContext(url, options);
   return simulate(app, ctx);
+};
+
+export function registerAsTest(app: FusionApp, testPlugin: FusionPlugin<*, *>) {
+  app.register(testPlugin);
+  app.resolve();
+
+  return {
+    request: request(app),
+    render: render(app),
+  };
 }
 
 // Export test runner functions from jest

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -1,10 +1,14 @@
 /* eslint-env node */
+// @flow
 
 import {parse} from 'url';
+import type {Context} from 'fusion-core';
 
-export function mockContext(url, options) {
+declare var __BROWSER__: boolean;
+
+export function mockContext(url: string, options: *): Context {
   if (__BROWSER__) {
-    const parsedUrl = parse(url);
+    const parsedUrl = {...parse(url)};
     const {path} = parsedUrl;
     parsedUrl.path = parsedUrl.pathname;
     parsedUrl.url = path;
@@ -23,7 +27,9 @@ export function mockContext(url, options) {
    * https://github.com/koajs/koa/blob/master/LICENSE
    */
   const socket = new Stream.Duplex();
+  //$FlowFixMe
   req = Object.assign({headers: {}, socket}, Stream.Readable.prototype, req);
+  //$FlowFixMe
   res = Object.assign({_headers: {}, socket}, Stream.Writable.prototype, res);
   req.socket.remoteAddress = req.socket.remoteAddress || '127.0.0.1';
   res.getHeader = k => res._headers[k.toLowerCase()];
@@ -31,11 +37,12 @@ export function mockContext(url, options) {
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
 
   const app = new Koa();
+  //$FlowFixMe
   const ctx = app.createContext(req, res);
   return ctx;
 }
 
-export function renderContext(url, options) {
+export function renderContext(url: string, options: any): Context {
   options = Object.assign(options, {headers: {accept: 'text/html'}});
   return mockContext(url, options);
 }

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -1,6 +1,10 @@
-import {compose} from 'fusion-core';
+// @flow
 
-export default function simulate(app, ctx) {
+// $FlowFixMe
+import FusionApp, {compose} from 'fusion-core';
+import type {Context} from 'fusion-core';
+
+export default function simulate(app: FusionApp, ctx: Context): Promise<*> {
   app.resolve();
   return compose(app.plugins)(ctx, () => Promise.resolve()).then(() => ctx);
 }

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -5,6 +5,5 @@ import FusionApp, {compose} from 'fusion-core';
 import type {Context} from 'fusion-core';
 
 export default function simulate(app: FusionApp, ctx: Context): Promise<*> {
-  app.resolve();
   return compose(app.plugins)(ctx, () => Promise.resolve()).then(() => ctx);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,8 +1665,8 @@ camelcase@^1.0.2:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
 caniuse-lite@^1.0.30000789:
-  version "1.0.30000790"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000790.tgz#c954cca780046f34c4b433d324ef419e1db51a53"
+  version "1.0.30000791"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000791.tgz#8e35745efd483a3e23bb7d350990326d2319fc16"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2080,9 +2080,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@^1.1.0, depd@~1.1.1:
+depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+
+depd@^1.1.0, depd@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -2804,7 +2808,7 @@ fusion-core@0.3.0-2:
 
 fusion-tokens@^0.0.4:
   version "0.0.4"
-  resolved "https://unpm.uberinternal.com/fusion-tokens/-/fusion-tokens-0.0.4.tgz#b84c58e2de8e06d3e63c2c182da7e023ccfb50ec"
+  resolved "https://registry.yarnpkg.com/fusion-tokens/-/fusion-tokens-0.0.4.tgz#b84c58e2de8e06d3e63c2c182da7e023ccfb50ec"
 
 gauge@~2.7.3:
   version "2.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,10 @@ fusion-core@0.3.0-2:
     node-mocks-http "^1.6.6"
     toposort "^1.0.6"
 
+fusion-tokens@^0.0.4:
+  version "0.0.4"
+  resolved "https://unpm.uberinternal.com/fusion-tokens/-/fusion-tokens-0.0.4.tgz#b84c58e2de8e06d3e63c2c182da7e023ccfb50ec"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
Fixes #364

Primary changes:
* Add `getSimulator` to encapsulate plugin resolution and expose `render` and `request`
* Add Flow types, where appropriate
* Update unit tests - includes addition of test with resolution of plugin dependencies
* Update `README.md`
