### PR TITLE
Change default status to 404 without affecting Koa default semantics

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -1,0 +1,59 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import test from 'tape-cup';
+import App from 'fusion-core';
+
+import {getSimulator} from '../index.js';
+
+test('status is 404 if ctx.body is never updated', async t => {
+  const app = new App('el', el => el);
+  const ctx = await getSimulator(app).request('/');
+  t.equals(ctx.status, 404, 'status defaults to 404');
+  t.end();
+});
+
+test('status is 200 if ctx.body is updated in request', async t => {
+  const app = new App('el', el => el);
+  app.middleware((ctx, next) => {
+    ctx.body = {ok: 1};
+    return next();
+  });
+  const ctx = await getSimulator(app).request('/');
+  t.equals(ctx.status, 200, 'status defaults to 200');
+  t.end();
+});
+
+test('status is set if ctx.status is updated in request', async t => {
+  const app = new App('el', () => 'hello');
+  app.middleware((ctx, next) => {
+    ctx.status = 500;
+    ctx.body = {error: 'error'};
+    return next();
+  });
+  const ctx = await getSimulator(app).render('/');
+  t.equals(ctx.status, 500, 'status is set');
+  t.end();
+});
+
+test('status is 200 if ctx.body is updated in render', async t => {
+  const app = new App('el', () => 'hello');
+  const ctx = await getSimulator(app).render('/');
+  t.equals(ctx.status, 200, 'status defaults to 200');
+  t.end();
+});
+
+test('status is set if ctx.status is updated in render', async t => {
+  const app = new App('el', () => 'hello');
+  app.middleware((ctx, next) => {
+    ctx.status = 500;
+    return next();
+  });
+  const ctx = await getSimulator(app).render('/');
+  t.equals(ctx.status, 500, 'status is set');
+  t.end();
+});
+

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -56,4 +56,3 @@ test('status is set if ctx.status is updated in render', async t => {
   t.equals(ctx.status, 500, 'status is set');
   t.end();
 });
-

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -44,6 +44,7 @@ export function mockContext(url: string, options: *): Context {
   res.setHeader = (k, v) => (res._headers[k.toLowerCase()] = v);
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
 
+  //$FlowFixMe
   return new Koa().createContext(req, res);
 }
 

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -36,17 +36,15 @@ export function mockContext(url: string, options: *): Context {
   //$FlowFixMe
   req = Object.assign({headers: {}, socket}, Stream.Readable.prototype, req);
   //$FlowFixMe
-  res = Object.assign({_headers: {}, socket}, Stream.Writable.prototype, res);
+  res = Object.assign({_headers: {}, socket}, Stream.Writable.prototype, res, {
+    statusCode: 404,
+  });
   req.socket.remoteAddress = req.socket.remoteAddress || '127.0.0.1';
   res.getHeader = k => res._headers[k.toLowerCase()];
   res.setHeader = (k, v) => (res._headers[k.toLowerCase()] = v);
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
 
-  const app = new Koa();
-  //$FlowFixMe
-  const ctx = app.createContext(req, res);
-  ctx.status = 404;
-  return ctx;
+  return new Koa().createContext(req, res);
 }
 
 export function renderContext(url: string, options: any): Context {


### PR DESCRIPTION
Resolves #49 

Rationale:

Koa has setter semantics that are relied on by downstream packages:

1 - if ctx.status is not set and ctx.body is not set, ctx.status is 404
2 - if ctx.status is not set and ctx.body is set, ctx.status is 200
3 - if ctx.status is set and ctx.body is set, ctx.status is not updated by the ctx.body setter

Previously, #50 changed the default status via semantic 3, which is incorrect, since it makes all requests 404 unless a downstream explicitly sets ctx.status. Instead, we want to rely on Koa default semantics so that ctx.status defaults to 404 if ctx.body is unset, but setting ctx.body updates an unset ctx.status to 200.

For example, the following should yield a 200 (despite not explicitly setting ctx.status):

```js
const app = new App(...);
app.middleware((ctx, next) => {
  ctx.body = {ok: 1};
  return next();
});
```

And the following should yield a 404

```js
const app = new App(...);
app.middleware((ctx, next) => {
  // updates nothing
  return next();
});

```

Resolution:

Instead of setting ctx.status, this PR updates the underlying res.statusCode property