### PR TITLE
Add doesNotThrow overload without regex

### DIFF
--- a/flow-typed/tape-cup_v4.x.x.js
+++ b/flow-typed/tape-cup_v4.x.x.js
@@ -76,6 +76,7 @@ declare interface tape$Context {
   throws(fn: Function, expected?: RegExp | Function, msg?: string): void,
   throws(fn: Function, msg?: string): void,
   doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void,
+  doesNotThrow(fn: Function, msg?: string): void;
 
   timeoutAfter(ms: number): void,
 


### PR DESCRIPTION
Verification builds are currently failing because we use this overload, but it's not defined in the tape-cup flow-typed lib. This specific file is used for our verification builds, so update it with the override from fusion-plugin-node-performance-emitter.