### PR TITLE
Add getService as a new helper function for testing services

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -10,7 +10,7 @@ import test from 'tape-cup';
 import App, {createPlugin, createToken} from 'fusion-core';
 import type {Token, FusionPlugin} from 'fusion-core';
 
-import {getSimulator, test as exportedTest} from '../index.js';
+import {getSimulator, getService, test as exportedTest} from '../index.js';
 
 test('simulate render request', async t => {
   const flags = {render: false};
@@ -121,4 +121,58 @@ test('test throws when not using test-app', async t => {
     );
     t.end();
   }
+});
+
+test('getService - returns service as expected, with no dependencies', async t => {
+  const app = new App('hi', el => el);
+  const simplePlugin = createPlugin({
+    provides() {
+      return {meaningOfLife: 42};
+    },
+  });
+
+  const service = getService(app, simplePlugin);
+  t.ok(service);
+  t.equal(service.meaningOfLife, 42);
+
+  t.end();
+});
+
+test('getService - returns service as expected, with dependencies', async t => {
+  const meaningOfLifeToken = createToken('meaning-of-life-token');
+  const meaningOfLifePlugin = createPlugin({
+    provides() {
+      return 42;
+    },
+  });
+  const simplePlugin = createPlugin({
+    deps: {meaning: meaningOfLifeToken},
+    provides: ({meaning}) => {
+      return {meaningOfLife: meaning};
+    },
+  });
+
+  const app = new App('hi', el => el);
+  app.register(meaningOfLifeToken, meaningOfLifePlugin);
+
+  const service = getService(app, simplePlugin);
+  t.ok(service);
+  t.equal(service.meaningOfLife, 42);
+
+  t.end();
+});
+
+test('getService - throws as expected due to missing dependency', async t => {
+  const meaningOfLifeToken = createToken('meaning-of-life-token');
+  const simplePlugin = createPlugin({
+    deps: {meaning: meaningOfLifeToken},
+    provides: ({meaning}) => {
+      return {meaningOfLife: meaning};
+    },
+  });
+  const app = new App('hi', el => el);
+
+  t.throws(() => getService(app, simplePlugin));
+
+  t.end();
 });


### PR DESCRIPTION
**Impetus**

Many Flow failures due to tests exposing and using the internals of `FusionPlugins`.  See [this|https://buildkite.com/uberopensource/fusion-release-verification/builds/431#728bdd19-e437-4077-8745-2c88cc84dcce] as an example.

**Solution**

Create a utility helper to make extracting a service from a plugin easier.