### PR TITLE
Simulate request with body

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -65,6 +65,6 @@ test('body contains some message', async t => {
     body: {message: 'test'},
   });
   t.equals(ctx.status, 404, 'status is set');
-  t.equals(ctx.res.body.message, 'test', 'body is set');
+  t.equals(ctx.req.body.message, 'test', 'body is set');
   t.end();
 });

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -58,3 +58,13 @@ test('status is set if ctx.status is updated in render', async t => {
   t.equals(ctx.status, 500, 'status is set');
   t.end();
 });
+
+test('body contains some message', async t => {
+  const app = new App('el', () => 'hello');
+  const ctx = await getSimulator(app).request('/_errors', {
+    body: {message: 'test'},
+  });
+  t.equals(ctx.status, 404, 'status is set');
+  t.equals(ctx.res.body.message, 'test', 'body is set');
+  t.end();
+});

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -65,6 +65,7 @@ test('body contains some message', async t => {
     body: {message: 'test'},
   });
   t.equals(ctx.status, 404, 'status is set');
+  // $FlowFixMe
   t.equals(ctx.req.body.message, 'test', 'body is set');
   t.end();
 });

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -13,7 +13,7 @@ import type {Context} from 'fusion-core';
 
 declare var __BROWSER__: boolean;
 
-export function mockContext(url: string, options: *): Context {
+export function mockContext(url: string, options: {body?: {[key: string]: any}}): Context {
   if (__BROWSER__) {
     const parsedUrl = {...parse(url)};
     const {path} = parsedUrl;

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -13,7 +13,10 @@ import type {Context} from 'fusion-core';
 
 declare var __BROWSER__: boolean;
 
-export function mockContext(url: string, options: {body?: {[key: string]: any}}): Context {
+export function mockContext(
+  url: string,
+  options: {body?: {[key: string]: any}}
+): Context {
   if (__BROWSER__) {
     const parsedUrl = {...parse(url)};
     const {path} = parsedUrl;

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -47,7 +47,7 @@ export function mockContext(url: string, options: *): Context {
   res.setHeader = (k, v) => (res._headers[k.toLowerCase()] = v);
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
   if (options.body) {
-    res.body = options.body;
+    req.body = options.body;
   }
   //$FlowFixMe
   return new Koa().createContext(req, res);

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -46,7 +46,9 @@ export function mockContext(url: string, options: *): Context {
   res.getHeader = k => res._headers[k.toLowerCase()];
   res.setHeader = (k, v) => (res._headers[k.toLowerCase()] = v);
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
-
+  if (options.body) {
+    res.body = options.body;
+  }
   //$FlowFixMe
   return new Koa().createContext(req, res);
 }


### PR DESCRIPTION
We fix the response to have body placed in tests. The context should have alias to body of reponse
But according to createContext, which we use
https://github.com/koajs/koa/blob/master/lib/application.js#L159
it never exposes those vars

P.S.
https://github.com/koajs/koa/blob/master/docs/api/context.md
