### PR TITLE
Expose pass-through of snapshotName argument for `matchSnapshot`

### DIFF
--- a/src/__jest__/__snapshots__/jest.js.snap
+++ b/src/__jest__/__snapshots__/jest.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matchSnapshot 1`] = `
+exports[`matchSnapshot: snapshot name 1`] = `
 Object {
   "foo": "bar",
 }

--- a/src/__jest__/__snapshots__/jest.js.snap
+++ b/src/__jest__/__snapshots__/jest.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matchSnapshot: snapshot name 1`] = `
+exports[`matchSnapshot 1`] = `
+Object {
+  "foo": "bar",
+}
+`;
+
+exports[`matchSnapshot with name: my snapshot name 1`] = `
 Object {
   "foo": "bar",
 }

--- a/src/__jest__/jest.js
+++ b/src/__jest__/jest.js
@@ -17,5 +17,5 @@ test('function mocks', assert => {
 
 test('matchSnapshot', assert => {
   const myObj = {foo: 'bar'};
-  assert.matchSnapshot(myObj);
+  assert.matchSnapshot(myObj, 'snapshot name');
 });

--- a/src/__jest__/jest.js
+++ b/src/__jest__/jest.js
@@ -17,5 +17,10 @@ test('function mocks', assert => {
 
 test('matchSnapshot', assert => {
   const myObj = {foo: 'bar'};
-  assert.matchSnapshot(myObj, 'snapshot name');
+  assert.matchSnapshot(myObj);
+});
+
+test('matchSnapshot with name', assert => {
+  const myObj = {foo: 'bar'};
+  assert.matchSnapshot(myObj, 'my snapshot name');
 });

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ type MockFunctionType<TArgs, TReturn> = () => $Call<
   ExtractArgsReturnType<TArgs, TReturn>,
   JestFnType
 >;
-type MatchSnapshotType = (mixed, ?string) => void;
+type MatchSnapshotType = (tree: mixed, snapshotName: ?string) => void;
 type CallableAssertType = (
   assert: typeof assert & {matchSnapshot: MatchSnapshotType}
 ) => void | Promise<void>;

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ type MockFunctionType<TArgs, TReturn> = () => $Call<
   ExtractArgsReturnType<TArgs, TReturn>,
   JestFnType
 >;
-type MatchSnapshotType = mixed => void;
+type MatchSnapshotType = (mixed, string) => void;
 type CallableAssertType = (
   assert: typeof assert & {matchSnapshot: MatchSnapshotType}
 ) => void | Promise<void>;
@@ -90,7 +90,7 @@ let mockFunction: MockFunctionType<*, *>, test: any;
 if (typeof it !== 'undefined') {
   // Surface snapshot testing
   // $FlowFixMe
-  assert.matchSnapshot = tree => expect(tree).toMatchSnapshot();
+  assert.matchSnapshot = (tree, snapshotName) => expect(tree).toMatchSnapshot(snapshotName);
 
   /* eslint-env node, jest */
   test = (description, callback, ...rest) =>

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ type MockFunctionType<TArgs, TReturn> = () => $Call<
   ExtractArgsReturnType<TArgs, TReturn>,
   JestFnType
 >;
-type MatchSnapshotType = (mixed, string) => void;
+type MatchSnapshotType = (mixed, ?string) => void;
 type CallableAssertType = (
   assert: typeof assert & {matchSnapshot: MatchSnapshotType}
 ) => void | Promise<void>;

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,9 @@ let mockFunction: MockFunctionType<*, *>, test: any;
 if (typeof it !== 'undefined') {
   // Surface snapshot testing
   // $FlowFixMe
-  assert.matchSnapshot = (tree, snapshotName) => expect(tree).toMatchSnapshot(snapshotName);
+  assert.matchSnapshot = (tree, snapshotName) =>
+    // $FlowFixMe
+    expect(tree).toMatchSnapshot(snapshotName);
 
   /* eslint-env node, jest */
   test = (description, callback, ...rest) =>


### PR DESCRIPTION
This is poorly documented by Jest; but it is available. It allows users to provide custom names for snapshots so the following code

```js
test('it does render', (t) => {
  t.matchSnapshot('snapshot name');
});
```

Generates this snapshot name

```
exports[`it does render: snapshot name 1`] = ...
```

Documented here: https://facebook.github.io/jest/docs/en/expect.html#tomatchsnapshotpropertymatchers-snapshotname

And then the single-argument works because of here:
https://github.com/facebook/jest/blob/master/packages/jest-snapshot/src/index.js#L57