### PR TITLE
Pass body to context request

### DIFF
--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -65,7 +65,6 @@ test('body contains some message', async t => {
     body: {message: 'test'},
   });
   t.equals(ctx.status, 404, 'status is set');
-  // $FlowFixMe
-  t.equals(ctx.req.body.message, 'test', 'body is set');
+  t.deepEquals(ctx.request.body, {message: 'test'}, 'body is set');
   t.end();
 });

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -49,11 +49,15 @@ export function mockContext(
   res.getHeader = k => res._headers[k.toLowerCase()];
   res.setHeader = (k, v) => (res._headers[k.toLowerCase()] = v);
   res.removeHeader = k => delete res._headers[k.toLowerCase()];
+
+  // createContext is missing in Koa typings
+  const ctx = (new Koa(): any).createContext(req, res);
+
   if (options.body) {
-    req.body = options.body;
+    ctx.request.body = options.body;
   }
-  //$FlowFixMe
-  return new Koa().createContext(req, res);
+
+  return ctx;
 }
 
 export function renderContext(url: string, options: any): Context {


### PR DESCRIPTION
`ctx.request` is the koa request, which used by framework
`ctx.req` is the builtin node request