### PR TITLE
Fix flow types for mockFunction

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "cover": "npm run build-test && nyc npm run just-test",
-    "prepublish": "npm run transpile"
+    "prepublish": "npm run transpile",
+    "flow": "flow check"
   },
   "dependencies": {
     "assert": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "cover": "npm run build-test && nyc npm run just-test",
-    "prepublish": "npm run transpile",
-    "flow": "flow check"
+    "prepublish": "npm run transpile"
   },
   "dependencies": {
     "assert": "^1.4.1",

--- a/src/__jest__/jest.js
+++ b/src/__jest__/jest.js
@@ -15,6 +15,13 @@ test('function mocks', assert => {
   assert.equal(myMock.mock.calls.length, 1);
 });
 
+test('function mocks with an argument', assert => {
+  const myMock = mockFunction(() => null);
+  assert.equal(myMock.mock.calls.length, 0);
+  myMock();
+  assert.equal(myMock.mock.calls.length, 1);
+});
+
 test('matchSnapshot', assert => {
   const myObj = {foo: 'bar'};
   assert.matchSnapshot(myObj);

--- a/src/index.js
+++ b/src/index.js
@@ -74,10 +74,9 @@ type ExtractArgsReturnType<TArguments, TReturn> = <R>(
 ) => R;
 type JestFnType = $PropertyType<JestObjectType, 'fn'>;
 // eslint-disable-next-line flowtype/generic-spacing
-type MockFunctionType<TArgs, TReturn> = () => $Call<
-  ExtractArgsReturnType<TArgs, TReturn>,
-  JestFnType
->;
+type MockFunctionType<TArgs, TReturn> = (
+  ...args: TArgs
+) => $Call<ExtractArgsReturnType<TArgs, TReturn>, JestFnType>;
 type MatchSnapshotType = (tree: mixed, snapshotName: ?string) => void;
 type CallableAssertType = (
   assert: typeof assert & {matchSnapshot: MatchSnapshotType}
@@ -103,7 +102,6 @@ if (typeof it !== 'undefined') {
   const notSupported = () => {
     throw new Error('Can’t import test() when not using the test-app target.');
   };
-  // $FlowFixMe
   test = notSupported;
   mockFunction = notSupported;
 }


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-test-utils/issues/134

The `MockFunctionType` was missing the ability to pass in function arguments.