### PR TITLE
Remove fusion-tokens as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-react": "7.7.0",
     "flow-bin": "^0.70.0",
     "fusion-core": "^1.2.2",
-    "fusion-tokens": "^1.0.0",
     "jest": "22.4.2",
     "jest-cli": "22.4.2",
     "nyc": "11.4.1",
@@ -62,8 +61,7 @@
     "node-mocks-http": "^1.6.6"
   },
   "peerDependencies": {
-    "fusion-core": "^1.0.0",
-    "fusion-tokens": "^1.0.0"
+    "fusion-core": "^1.0.0"
   },
   "engines": {
     "node": ">= 8.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,10 +3117,6 @@ fusion-core@^1.2.2:
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
 
-fusion-tokens@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fusion-tokens/-/fusion-tokens-1.0.3.tgz#e247a076ef145337287e103ecbc42486594e96c5"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
This was probably added in when createToken was under fusion-tokens but since it's under fusion-core now this is unused.

Removing this also lets us remove fusion-tokens from some other plugins that have this package as a dev dependency.