### PR TITLE
Allow simulator headers to be overridden

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -67,22 +67,6 @@ test('simulate non-render request', async t => {
   }
 });
 
-test('simulator accepts extra headers', async t => {
-  if (__NODE__) {
-    const app = new App('hi', () => {});
-    const simulator = getSimulator(app);
-
-    const ctx = await simulator.render('/', {
-      headers: {
-        'x-header': 'value',
-      }
-    });
-
-    t.equal(ctx.request.headers['x-header'], 'value');
-  }
-  t.end();
-});
-
 test('use simulator with fixture and plugin dependencies', async t => {
   // Dependency-less plugin
   type MessageType = {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -67,6 +67,22 @@ test('simulate non-render request', async t => {
   }
 });
 
+test('simulator accepts extra headers', async t => {
+  if (__NODE__) {
+    const app = new App('hi', () => {});
+    const simulator = getSimulator(app);
+
+    const ctx = await simulator.render('/', {
+      headers: {
+        'x-header': 'value',
+      }
+    });
+
+    t.equal(ctx.request.headers['x-header'], 'value');
+  }
+  t.end();
+});
+
 test('use simulator with fixture and plugin dependencies', async t => {
   // Dependency-less plugin
   type MessageType = {

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -112,7 +112,7 @@ test('simulator accepts extra headers', async t => {
   const ctx = await simulator.render('/', {
     headers: {
       'x-header': 'value',
-    }
+    },
   });
 
   t.equal(ctx.request.headers['x-header'], 'value');

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -105,6 +105,20 @@ test('status is set if ctx.status is updated in render', async t => {
   t.end();
 });
 
+test('simulator accepts extra headers', async t => {
+  const app = new App('hi', () => {});
+  const simulator = getSimulator(app);
+
+  const ctx = await simulator.render('/', {
+    headers: {
+      'x-header': 'value',
+    }
+  });
+
+  t.equal(ctx.request.headers['x-header'], 'value');
+  t.end();
+});
+
 test('body contains some message', async t => {
   const app = new App('el', () => 'hello');
   const ctx = await getSimulator(app).request('/_errors', {

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -61,6 +61,8 @@ export function mockContext(
 }
 
 export function renderContext(url: string, options: any = {}): Context {
-  options = Object.assign(options, {headers: Object.assign({accept: 'text/html'}, options.headers)});
+  options = Object.assign(options, {
+    headers: Object.assign({accept: 'text/html'}, options.headers),
+  });
   return mockContext(url, options);
 }

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -60,7 +60,7 @@ export function mockContext(
   return ctx;
 }
 
-export function renderContext(url: string, options: any): Context {
-  options = Object.assign(options, {headers: {accept: 'text/html'}});
+export function renderContext(url: string, options: any = {}): Context {
+  options = Object.assign(options, {headers: Object.assign({accept: 'text/html'}, options.headers)});
   return mockContext(url, options);
 }


### PR DESCRIPTION
I have a testing use case similar to the [example](https://github.com/fusionjs/fusion-test-utils#example) but realized that the current behavior actually doesn't allow headers to be overridden this way. Fixing so simulate respects passed-in headrers