### PR TITLE
Fix mock context for headers in Node 10

### DIFF
--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -19,6 +19,13 @@ type ContextOptions = {|
   method?: string,
 |};
 
+const outHeadersKey = __BROWSER__
+  ? ''
+  : Object.getOwnPropertySymbols(
+      // $FlowFixMe
+      new (require('http')).OutgoingMessage()
+    ).filter(sym => /outHeadersKey/.test(sym.toString()))[0];
+
 const defaultContextOptions: ContextOptions = {
   headers: {},
 };
@@ -41,6 +48,7 @@ export function createRequestContext(
   const Koa = require('koa');
   let req = httpMocks.createRequest({url, ...options});
   let res = httpMocks.createResponse();
+  res[outHeadersKey] = null; // required for headers to work correctly in Node >10
 
   /**
    * Copied from https://github.com/koajs/koa/blob/master/test/helpers/context.js

--- a/src/mock-context.js
+++ b/src/mock-context.js
@@ -19,13 +19,6 @@ type ContextOptions = {|
   method?: string,
 |};
 
-const outHeadersKey = __BROWSER__
-  ? ''
-  : Object.getOwnPropertySymbols(
-      // $FlowFixMe
-      new (require('http')).OutgoingMessage()
-    ).filter(sym => /outHeadersKey/.test(sym.toString()))[0];
-
 const defaultContextOptions: ContextOptions = {
   headers: {},
 };
@@ -48,6 +41,11 @@ export function createRequestContext(
   const Koa = require('koa');
   let req = httpMocks.createRequest({url, ...options});
   let res = httpMocks.createResponse();
+
+  const outHeadersKey = Object.getOwnPropertySymbols(
+    // $FlowFixMe
+    new (require('http')).OutgoingMessage()
+  ).filter(sym => /outHeadersKey/.test(sym.toString()))[0];
   res[outHeadersKey] = null; // required for headers to work correctly in Node >10
 
   /**


### PR DESCRIPTION
quoting the original task:
> In previous versions of node, headers were automatically populated with an empty object, even if initially undefined: https://github.com/nodejs/node/blob/v8.x/lib/_http_outgoing.js#L500-L504
> Starting with node 10, headers are not automatically populated if initially undefined (note the triple equals): https://github.com/nodejs/node/blob/v10.x/lib/_http_outgoing.js#L475-L477

To make the mock responses functional, we have to extract the internal symbol(`outHeadersKey`) and initialize the property with `null`. Otherwise low-level libraries such as [`cookies`](https://github.com/pillarjs/cookies/blob/88121dc0472a259deb81068c4f36e4ccd67d9c65/index.js#L114) can not work with the mock responses.